### PR TITLE
Detect used Metamask network

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -76,7 +76,7 @@ export default {
           );
           window.web3 = new Web3(
             new Web3.providers.HttpProvider(
-              "https://mainnet.infura.io/v3/fb32a606c5c646c7932e43cfaf6c39df"
+              "https://kovan.infura.io/v3/fb32a606c5c646c7932e43cfaf6c39df"
             )
           );
           this.INIT_APP(window.web3);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -152,7 +152,14 @@ export default new Vuex.Store({
         commit(mutations.SET_ACCOUNT, account);
       }
 
-      let cherryswap = await Cherryswap.deployed()
+      let cherryswap;
+      try {
+        cherryswap = await Cherryswap.deployed()
+      } catch (err) {
+        if(state.currentNetwork != "Kovan Ethereum Test Network") {
+          alert("Please change metamask network to Kovan testnet");
+        }
+      }
       console.log("contract")
       console.log(cherryswap)
 


### PR DESCRIPTION
In the current state, if user use a different network than Kovan, `Cherryswap.deployed()` will just throw an exception and the user will not notice what's happening without inspecting the console.
This PR fix detect if the network used, if different than Kovan show a message (Related to #13 ).

PS: First time with Vue.js so the code may not be perfect or need improvement! idk :dancer: 